### PR TITLE
feat(stack): add .From static method

### DIFF
--- a/src/stack/__tests__/stack.test.ts
+++ b/src/stack/__tests__/stack.test.ts
@@ -26,7 +26,7 @@ describe('Stack', () => {
 
     test('with values', () => {
       const instance = getInstance([1, 2, 3])
-      expect(instance.length()).toEqual(3)
+      expect(instance.length).toEqual(3)
     })
   })
 
@@ -35,7 +35,7 @@ describe('Stack', () => {
       const instance = getInstance<number>()
       instance.push(1)
 
-      expect(instance.length()).toEqual(1)
+      expect(instance.length).toEqual(1)
     })
 
     test('adds items in the correct order', () => {
@@ -60,7 +60,7 @@ describe('Stack', () => {
       const instance = getInstance([1])
       const item = instance.pop()
 
-      expect(instance.length()).toEqual(0)
+      expect(instance.length).toEqual(0)
       expect(item).toEqual(1)
     })
 
@@ -74,7 +74,7 @@ describe('Stack', () => {
       expect(one).toEqual(1)
       expect(two).toEqual(2)
       expect(three).toEqual(3)
-      expect(instance.length()).toEqual(0)
+      expect(instance.length).toEqual(0)
     })
   })
 
@@ -84,7 +84,27 @@ describe('Stack', () => {
       const last = instance.peek()
 
       expect(last).toEqual(3)
-      expect(instance.length()).toEqual(3)
+      expect(instance.length).toEqual(3)
+    })
+
+    test('empty stack returns null', () => {
+      const instance = getInstance()
+
+      expect(instance.peek()).toEqual(null)
+    })
+  })
+
+  describe('static methods', () => {
+    describe('.From', () => {
+      test('has a static From method', () => {
+        expect(Stack.From).toBeDefined()
+      })
+
+      test('creates a stack from the provided values', () => {
+        const instance = Stack.From([1, 2, 3])
+
+        expect(instance.length).toEqual(3)
+      })
     })
   })
 })

--- a/src/stack/stack.ts
+++ b/src/stack/stack.ts
@@ -9,7 +9,12 @@ class Stack<T> {
     }
   }
 
-  public length(): number {
+  public static From<T>(values: Array<T>) {
+    const stack = new Stack(values)
+    return stack
+  }
+
+  get length(): number {
     return this.stack.length
   }
 


### PR DESCRIPTION
`Stack.From<T>(initialValues)` will return a new stack with the initial values

BREAKING CHANGE: .length is now a property, and not a method